### PR TITLE
fix(release): rename workflow to match PyPI trusted publisher

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: PyPI Publish
 
 on:
   push:


### PR DESCRIPTION
PyPI trusted publisher matches on the workflow filename. The publisher is configured for `pypi-publish.yml` (the v9.4.0 name); the v10.0.0 release run sent `release.yml` and PyPI refused with `invalid-publisher`. Rename to match.